### PR TITLE
Add option to disable helmet (only rate limiter)

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ module.exports = (app, config) => {
   app.use(getIPAdress);
   rateLimiter(app, config);
 
+  if (config.disableHelmet) {
+    return;  
+  }
+
   let skips = skipAssets(config);
 
   app.use("/:anything", function (req, res, next) {

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -1,0 +1,33 @@
+const request = require("supertest");
+const expect = require("chai").expect;
+const express = require('express');
+const applySalus = require("../index.js");
+
+describe("Rate limiting", function () {
+  const app = express();
+  const config = {
+    disableHelmet: true,
+    rateLimiter: {
+      windowMs: 10000, // 10 seconds
+      max: 10, // Limit each IP to 10 requests per `window` (here, per 10 seconds)
+    },
+  };
+  applySalus(app, config);
+  app.use("/ping", function (req, res) {
+    res.send("ok");
+  });
+
+  it("should insert rate limiting factors headers", function (done) {
+    request(app).get("/ping").expect("X-RateLimit-Limit", "10").expect(200, done);
+  });
+
+  it("should not insert helmet headers", async function () {
+    let response;
+    response = await request(app).get("/ping");
+    let headers = response.headers;
+    expect(headers['content-security-policy']).eq(undefined);
+    expect(headers['cross-origin-embedder-policy']).eq(undefined);
+    expect(headers['x-dns-prefetch-control']).eq(undefined);
+    expect(headers['x-frame-options']).eq(undefined);
+  });
+});


### PR DESCRIPTION
This commit implement a simple option that when added to the `salus.config.js` file will disable the security and only run the rate limiter.