### PR TITLE
Fix a previous wrong fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you want to learn more about securing a web app:
 
 # History
 
-**0.0.9-beta.4**
+**0.0.9-beta.5**
 - fix issue with config.disableHelmet blocking all not-static assets from loading
  
 # Credits

--- a/middlewares/insertNonce.js
+++ b/middlewares/insertNonce.js
@@ -14,13 +14,13 @@ function insertNonce(res, req, html, index_file) {
   if (/Firefox/.test(req.get("user-agent"))) {
     debug('Firefox detected: skipping nonce insertion')
     return html;
-  } else if (res.disableHelmet) {
-    return html;
-  } else {
+  } else if (res.locals.nonce) {
     return html
       .replace(/<script/g, `<script nonce="${res.locals.nonce}"`)
       .replace(/<link/g, `<link nonce="${res.locals.nonce}"`)
       .replace(/<style/g, `<style nonce="${res.locals.nonce}"`);
+  } else {
+    return html;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superpowerlabs/salus",
-  "version": "0.0.9-beta.4",
+  "version": "0.0.9-beta.5",
   "description": "A set of security middleware to secure a webapp with rate limiting and CSP headers",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
This fixes a previous fix in https://github.com/superpowerlabs/salus/commit/ab900e2a5189bd155cdc3b4dcb272092b9595a8d that was trying to avoid Salus blocking React routes from loading correctly when disableHelmet is true in the config. 