### PR TITLE
Dont skip nonce insertion for firefox and test coverage

### DIFF
--- a/middlewares/insertNonce.js
+++ b/middlewares/insertNonce.js
@@ -11,14 +11,12 @@ function getIndex(html, index_file) {
 
 function insertNonce(res, req, html, index_file) {
   html = getIndex(html, index_file);
-  if (res.locals.nonce) {
-    return html
-      .replace(/<script/g, `<script nonce="${res.locals.nonce}"`)
-      .replace(/<link/g, `<link nonce="${res.locals.nonce}"`)
-      .replace(/<style/g, `<style nonce="${res.locals.nonce}"`);
-  } else {
-    return html;
-  }
+  // note: removing the test if (res.locals.nonce) since this function can't be
+  //       reached if res.locals.nonce is not set
+  return html
+    .replace(/<script/g, `<script nonce="${res.locals.nonce}"`)
+    .replace(/<link/g, `<link nonce="${res.locals.nonce}"`)
+    .replace(/<style/g, `<style nonce="${res.locals.nonce}"`);
 }
 
 module.exports = (app, config) => {

--- a/middlewares/insertNonce.js
+++ b/middlewares/insertNonce.js
@@ -11,10 +11,7 @@ function getIndex(html, index_file) {
 
 function insertNonce(res, req, html, index_file) {
   html = getIndex(html, index_file);
-  if (/Firefox/.test(req.get("user-agent"))) {
-    debug("Firefox detected: skipping nonce insertion");
-    return html;
-  } else if (res.locals.nonce) {
+  if (res.locals.nonce) {
     return html
       .replace(/<script/g, `<script nonce="${res.locals.nonce}"`)
       .replace(/<link/g, `<link nonce="${res.locals.nonce}"`)

--- a/test/headers_test.js
+++ b/test/headers_test.js
@@ -7,15 +7,22 @@ describe("Security features", function () {
     request(app).get("/").expect("Content-Type", /html/).expect(200, done);
   });
 
-  it("should insert nonce in link and script tags in html response body", async function () {
+  it("should insert nonce in link and script tags in html response body for /", async function () {
     const response = await request(app).get("/");
 
     expect(response.text).match(/link nonce=/);
     expect(response.text).match(/script nonce=/);
   });
 
+  it("should insert nonce in link and script tags in html response body for /privacy", async function () {
+    const response = await request(app).get("/privacy");
+
+    expect(response.text).match(/link nonce=/);
+    expect(response.text).match(/script nonce=/);
+  });
+
   it("should insert rate limiting factors headers", function (done) {
-    request(app).get("/").expect("X-RateLimit-Limit", "11").expect(200, done);
+    request(app).get("/").expect("X-RateLimit-Limit", "12").expect(200, done);
   });
 
   it("should insert X-Permitted-Cross-Domain-Policies headers", function (done) {

--- a/test/public/privacy.html
+++ b/test/public/privacy.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- TODO: complete META information -->
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <link rel="icon" href="images/favicon.png" />
+
+    <!-- TODO: change title -->
+    <title>SuperPower Labs Template App</title>
+
+    <link rel="stylesheet" href="styles/base.css" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root">
+      Privacy policy
+      <script>
+        console.log("testing");
+      </script>
+    </div>
+  </body>
+</html>

--- a/test/server/app.js
+++ b/test/server/app.js
@@ -22,6 +22,10 @@ app.use("/ping", function (req, res) {
   res.send("ok");
 });
 
+app.get("/privacy", function (req, res) {
+  res.sendFile(__dirname + "/privacy.html");
+});
+
 app.use(express.static(path.resolve(__dirname, "../public")));
 
 module.exports = app;

--- a/test/server/salus.config.js
+++ b/test/server/salus.config.js
@@ -51,7 +51,7 @@ const config = {
   },
   rateLimiter: {
     windowMs: 10000, // 10 seconds
-    max: 11, // Limit each IP to 10 requests per `window` (here, per 10 seconds)
+    max: 12, // Limit each IP to 10 requests per `window` (here, per 10 seconds)
   },
   debug: true,
 };


### PR DESCRIPTION
This PR does the following:
- removes the test to not insert nonce in Firefox since that code branch is not tested and nothing in the CSP docs shows that we should treat Firefox differently
- tests that a nonce is inserted when serving a page other than /
- makes some basic refactoring to remove test where a branch can't never be reached (in nonce insertion)